### PR TITLE
Replace spaces with underscores for languages that have spaces in the name

### DIFF
--- a/scripts/automate.py
+++ b/scripts/automate.py
@@ -181,7 +181,7 @@ def _generate_sample_program_index(program: subete.SampleProgram, path: pathlib.
         )
     else:
         doc.add_paragraph("{% raw %}")
-        doc.add_code(program.code().strip(), lang=program.language_name().lower())
+        doc.add_code(program.code().strip(), lang=program.language_name().lower().replace(" ", "_"))
         doc.add_paragraph("{% endraw %}")
 
     doc.add_paragraph(f"{program} was written by:") \


### PR DESCRIPTION
I fixed #550 . Underscores seem to be what is needed. Languages like Objective C are rendering with the appropriate syntax highlighting:
![image](https://user-images.githubusercontent.com/9933579/236629960-0a98370a-3f5c-4864-ada1-97ed5e85232f.png)
