### PR TITLE
Reduce noisy log output from subete and other improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Generate Webpages and Images
         run: python scripts/automate.py
 
+      - name: Build Webpages with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: docs/
+          destination: docs/_site
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+        # Only build webpage if not on main branch
+        if: ${{ github.ref != 'refs/heads/main' }}
+
       - name: Commit Changes
         uses: EndBug/add-and-commit@v9 
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: 0 0 * * 0
   workflow_dispatch:
@@ -22,22 +25,9 @@ jobs:
       - name: Install Dependencies
         run: pip install -r requirements.txt
 
-      - name: Generate Webpages
+      - name: Generate Webpages and Images
         run: python scripts/automate.py
 
-      - name: Generate Images
-        run: |
-          sources=sources/images/
-          images=docs/assets/images/
-          logo=icon-small.png
-          for file in "$sources"*
-          do
-            image-titler --path "$file" --output "$images" --logo "$images$logo" --no_title
-            filename=$(basename "$file")
-            edit=$(cd "$images" && ls -t | head -n1)
-            mv "$images$edit" "$images$filename" 
-          done
-      
       - name: Commit Changes
         uses: EndBug/add-and-commit@v9 
         with:
@@ -52,3 +42,6 @@ jobs:
         env:
           # This is necessary in order to push a commit to the repo
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged
+
+        # Only commit if on main branch
+        if: ${{ github.ref == 'refs/heads/main' }}

--- a/generate.sh
+++ b/generate.sh
@@ -1,22 +1,8 @@
 #!/bin/sh
 set -e
 
-echo "*** Generate Webpages ***"
+echo "*** Generate Webpages and Images ***"
 python scripts/automate.py
-
-echo ""
-echo "*** Generate Images ***"
-sources=sources/images/
-images=docs/assets/images/
-logo=icon-small.png
-for file in "$sources"*
-do
-    echo "- Processing ${file}"
-    image-titler --path "$file" --output "$images" --logo "$images$logo" --no_title
-    filename=$(basename "$file")
-    edit=$(cd "$images" && ls -t | head -n1)
-    mv "$images$edit" "$images$filename" 
-done
 
 echo ""
 echo "*** Build With Jekyll ***"


### PR DESCRIPTION
This PR fixes #561 and closes TheRenegadeCoder/subete#63 . This PR also includes the following:

- Run the same automation that pushes to main runs without committing changes (fixes #562 )
- Move image processing into `scripts/automate.py` since I'd like to change where images are stored in the future, and a simple set of shell commands isn't flexible enough