### PR TITLE
Modify Languages page to indicate untested and untestable languages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 snakemd~=2.1.0
-subete~=0.17.0
+subete~=0.18.0
 image-titler~=2.4.0
 glotter2~=0.8.0
 pyyaml~=6.0

--- a/scripts/automate.py
+++ b/scripts/automate.py
@@ -625,11 +625,17 @@ def generate_languages_index(repo: subete.Repo):
         times=times,
         image=_get_default_language_image()
     )
-    language_index.add_paragraph(
+    welcome_text = (
         "Welcome to the Languages page! Here, you'll find a list of all of the languages represented in the collection. "
-        f"At this time, there are {len(list(repo))} languages, of which {repo.total_tests()} are tested, "
-        f"and {repo.total_programs()} code snippets."
+        f"At this time, there are {len(list(repo))} languages, of which {repo.total_tests()} are tested"
     )
+    untestables = repo.total_untestables()
+    if untestables:
+        verb_untestables = "are" if untestables != 1 else "is"
+        welcome_text += f", {untestables} {verb_untestables} untestable"
+
+    welcome_text += f", and {repo.total_programs()} code snippets."
+    language_index.add_paragraph(welcome_text)
     language_index.add_heading("Language Collections by Letter", level=2)
     language_index.add_paragraph(
         "To help you navigate the collection, the following languages are organized alphabetically and grouped by first letter."
@@ -651,7 +657,7 @@ def generate_languages_index(repo: subete.Repo):
             f"of which {tests} {verb} tested"
         )
         if untestables:
-            language_statement += f", {verb_untestables} untestable"
+            language_statement += f", {untestables} {verb_untestables} untestable"
 
         language_index.add_paragraph(f"{language_statement}, and {snippets} code snippets.")
         languages.sort(key=lambda x: x.name().casefold())


### PR DESCRIPTION
I fixed #628 .

The "welcome" says this:

![image](https://github.com/TheRenegadeCoder/sample-programs-website/assets/9933579/39a5cf3c-ab35-4796-bc93-da94e0f7af5c)

Untested looks like this:

![image](https://github.com/TheRenegadeCoder/sample-programs-website/assets/9933579/c60a5c82-17a4-4060-b80b-087dc17761d6)

Untestable looks like this:

![image](https://github.com/TheRenegadeCoder/sample-programs-website/assets/9933579/5d56a649-e0bb-4b78-9d58-f9ed4b79ad25)

The link is to the untestable info in the Sample Programs repo. For example, [this](https://github.com/TheRenegadeCoder/sample-programs/blob/main/archive/m/mathematica/untestable.yml).