### PR TITLE
Add alphabet and 'Return to Top' links to Languages page

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -135,6 +135,34 @@ img {
   padding-bottom: 0px;
 }
 
+.letter-link {
+  list-style: none;
+  border-radius: 4px;
+  border: 0px;
+  display: block;
+  font-size: 22px;
+  font-family: serif;
+  font-weight: bold;
+}
+
+.letter-link>li {
+  display: inline-block;
+}
+
+.letter-link a {
+  color: $brand-color;
+}
+
+.letter-link a:hover {
+  color: darken($brand-color, 20%);
+}
+
+.letter-link>li+li:before {
+  color: #232323;
+  content: "|\00a0";
+  font-weight: normal;
+}
+
 @media print, screen and (max-width: 1200px) {
 
   div.wrapper {

--- a/generate.sh
+++ b/generate.sh
@@ -6,7 +6,8 @@ python scripts/automate.py
 
 echo ""
 echo "*** Build With Jekyll ***"
-export JEKYLL_VERSION=4.2.2
+# Use as close to the same version of Jekyll as GitHub actions is using
+export JEKYLL_VERSION="4.2.2"
 docker run --rm \
     -e "JEKYLL_UID=$(id -u)" \
     -e "JEKYLL_GID=$(id -g)" \

--- a/generate.sh
+++ b/generate.sh
@@ -6,8 +6,7 @@ python scripts/automate.py
 
 echo ""
 echo "*** Build With Jekyll ***"
-# Use as close to the same version of Jekyll as GitHub actions is using
-export JEKYLL_VERSION="4.2.2"
+export JEKYLL_VERSION=4.2.2
 docker run --rm \
     -e "JEKYLL_UID=$(id -u)" \
     -e "JEKYLL_GID=$(id -g)" \

--- a/generate.sh
+++ b/generate.sh
@@ -6,14 +6,21 @@ python scripts/automate.py
 
 echo ""
 echo "*** Build With Jekyll ***"
-export JEKYLL_VERSION=4.2.2
+# Use image that is a close to what is used for GitHub actions
+export GITHUB_PAGES_IMAGE=ghcr.io/actions/jekyll-build-pages
+export GITHUB_PAGES_VERSION=v1.0.9
 docker run --rm \
-    -e "JEKYLL_UID=$(id -u)" \
-    -e "JEKYLL_GID=$(id -g)" \
     -v "$PWD/docs:/srv/jekyll:Z" \
     -w "/srv/jekyll" \
-    -it jekyll/jekyll:$JEKYLL_VERSION \
-    bash -c "bundle install && jekyll build -V --config _config.yml"
+    -e JEKYLL_ENV=development \
+    --entrypoint="" \
+    -it $GITHUB_PAGES_IMAGE:$GITHUB_PAGES_VERSION \
+    bash -c "rm -f Gemfile.lock && \
+        bundle install && \
+        chown $(id -u):$(id -g) Gemfile.lock && \
+        jekyll clean --config _config.yml && \
+        jekyll build -V --config _config.yml && \
+        chown -R  $(id -u):$(id -g) _site"
 
 echo ""
 echo "*** Change Base URL For Generated Files ***"


### PR DESCRIPTION
I fixed #630 . Here is a screenshot of the changes:

![image](https://github.com/TheRenegadeCoder/sample-programs-website/assets/9933579/43616b5a-04c2-425a-94e8-33d61d69b42d)
![image](https://github.com/TheRenegadeCoder/sample-programs-website/assets/9933579/4b373b58-a5d4-4ff7-a622-2962d5e58014)
...

I modeled the CSS changes after what was done for the "breadcrumbs".

Also, I modified the `./generate.sh` script to use a docker image that is closer to what the GitHub action is using.