### PR TITLE
Expand program images for graphical languages (like Piet) and update snakemd to 2.3.0

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -135,6 +135,11 @@ img {
   padding-bottom: 0px;
 }
 
+.program-image {
+  width: 100%;
+  image-rendering: pixelated;
+}
+
 .letter-link {
   list-style: none;
   border-radius: 4px;

--- a/poetry.lock
+++ b/poetry.lock
@@ -1343,14 +1343,14 @@ files = [
 
 [[package]]
 name = "snakemd"
-version = "2.1.0"
+version = "2.3.0"
 description = "A markdown generation library for Python."
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "snakemd-2.1.0-py3-none-any.whl", hash = "sha256:95fefa3a09af57018b57e58b1aede641146d92eade9bb6d9fac415446d8237b5"},
-    {file = "snakemd-2.1.0.tar.gz", hash = "sha256:a061031ff0f8eb4af7423812e204b448c76e82ccd8137df1f8fc300ea18824cc"},
+    {file = "snakemd-2.3.0-py3-none-any.whl", hash = "sha256:20e42054db491eefd8ceca3e85f66086df262b75000aa37400da8591f6400995"},
+    {file = "snakemd-2.3.0.tar.gz", hash = "sha256:6a74b20ad5c8b6357fba5af4a5daea01251e6a793ee69f57a9aaceb17349d124"},
 ]
 
 [[package]]
@@ -1480,4 +1480,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "614b21102d7dd5be4274edac6034a7bba3ec4a3caf15c02e565d8e8410e3c8c1"
+content-hash = "bafcb126cd164e5b497fbb71047a59007b3aea1c943d2d7fa3275372730c2a73"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.9,<4.0"
 license = {file = "LICENSE" }
 
 dependencies = [
-    "snakemd (>=2.1.0,<2.2.0)",
+    "snakemd (>=2.3.0,<2.4.0)",
     "subete (>=0.20.0,<0.21.0)",
     "image-titler (>=2.4.0,<2.5.0)",
     "glotter2 (>=0.10.0,<0.11.0)",

--- a/scripts/automate.py
+++ b/scripts/automate.py
@@ -1,7 +1,6 @@
 from typing import Optional, Iterable, List, Set, Union
 import datetime
 import functools
-import imghdr
 import logging
 import os
 import pathlib
@@ -14,6 +13,7 @@ import snakemd
 import subete
 import glotter
 import yaml
+from subete import imghdr
 
 log = logging.getLogger("automate")
 AUTO_GEN_TEST_DOC_DIR = "sources/generated"
@@ -243,14 +243,11 @@ def _generate_sample_program_index(program: subete.SampleProgram, path: pathlib.
     if program.image_type():
         image_dest = path / pathlib.Path(program.project_path()).name
         shutil.copy(program.project_path(), image_dest)
+        image_uri = "/" + "/".join(image_dest.parts[1:])
+        image_description = f"{program.project_name()} in {program.language_name()}"
         doc.add_block(
-            snakemd.Paragraph(
-                [
-                    snakemd.Inline(
-                        f"{program.project_name()} in {program.language_name()}",
-                        image="/" + "/".join(image_dest.parts[1:])
-                    )
-                ]
+            snakemd.Raw(
+                f'''<img class="program-image" src="{image_uri}" alt="{image_description}">'''
             )
         )
     else:
@@ -297,7 +294,7 @@ def _generate_sample_program_index(program: subete.SampleProgram, path: pathlib.
         "How to Run the Solution"
     )
     try:
-        doc.dump("index", dir=str(path))
+        doc.dump("index", directory=str(path))
     except Exception:
         log.exception(f"Failed to write {path}")
 
@@ -441,7 +438,7 @@ def _generate_project_index(
     doc.add_block(snakemd.Paragraph([snakemd.Inline(f"Next Project ({next}) -->", link=next.requirements_url())]))
     doc.add_paragraph("</div>")
     doc.add_paragraph("</nav>")
-    doc.dump("index", dir=f"docs/projects/{project.pathlike_name()}")
+    doc.dump("index", directory=f"docs/projects/{project.pathlike_name()}")
 
 
 def _generate_language_index(language: subete.LanguageCollection):
@@ -481,7 +478,7 @@ def _generate_language_index(language: subete.LanguageCollection):
     _add_section(doc, "languages", language.pathlike_name(), "Description")
     _add_language_article_section(doc, repo, str(language))
     try:
-        doc.dump("index", dir=f"docs/languages/{language.pathlike_name()}")
+        doc.dump("index", directory=f"docs/languages/{language.pathlike_name()}")
     except Exception:
         log.exception(f"Failed to write {language.pathlike_name()}")
 
@@ -737,7 +734,7 @@ def generate_languages_index(repo: subete.Repo):
         language_index.add_block(snakemd.MDList(languages))
         language_index.add_block(snakemd.Paragraph(return_to_top))
 
-    language_index.dump("index", dir=str(language_index_path))
+    language_index.dump("index", directory=str(language_index_path))
 
 
 def _get_language_letter_links(repo: subete.Repo) -> str:
@@ -819,7 +816,7 @@ def generate_projects_index(repo: subete.Repo):
         for project in repo.approved_projects()
     ]
     projects_index.add_block(snakemd.MDList(projects))
-    projects_index.dump("index", dir=str(projects_index_path))
+    projects_index.dump("index", directory=str(projects_index_path))
 
 
 def copy_article_images(repo: subete.Repo):

--- a/sources/projects/transpose-matrix/description.md
+++ b/sources/projects/transpose-matrix/description.md
@@ -18,7 +18,7 @@ denoted by A<sup>T</sup>. For example, the following matrix could be the matrix 
 
 <table class="matrix">
     <tr>
-        <th class="empty;">&nbsp;</th>
+        <th class="empty">&nbsp;</th>
         <th>column 1</th>
         <th>column 2</th>
         <th>column 3</th>
@@ -50,7 +50,7 @@ Once transposed, A becomes the following matrix, A<sup>T</sup>:
         <th class="empty">&nbsp;</th>
         <th>column 1</th>
         <th>column 2</th>
-        <th >column 3</th>
+        <th>column 3</th>
     </tr>
     <tr>
         <th class="right">row 1</th>


### PR DESCRIPTION
I fixed #649
I fixed #650 

Also, I fixed the styling for Transpose Matrix.

Here's what Baklava in Piet used to look like:
![image](https://github.com/user-attachments/assets/e1905305-45c0-4924-b558-9ccfc62da754)

Here's what it looks like with my changes:
![image](https://github.com/user-attachments/assets/b4ae4fc6-42b2-4597-9db4-2487bdb20dc3)
